### PR TITLE
Added handling of escaped pipes.

### DIFF
--- a/spec/MarkdownTableFormatterSpec.js
+++ b/spec/MarkdownTableFormatterSpec.js
@@ -326,6 +326,21 @@ describe("MarkdownTableFormatter", function() {
 
     });
 
+    it("should keep escaped pipes on the same cells", function() {
+
+      table  = "| h1          | h2     |\n";
+      table += "|-------------|--------|\n";
+      table += "| a           | b \\| c |\n";
+      table += "| a \\| b \\| c | d      |\n";
+
+      // WHEN
+      mtf.format_table(table);
+
+      // THEN
+      expect(mtf.output_table).toEqual(table);
+
+    });
+
   });
 
 });

--- a/src/MarkdownTableFormatter.js
+++ b/src/MarkdownTableFormatter.js
@@ -93,7 +93,7 @@ MarkdownTableFormatter.prototype.import_table = function(table) {
 
     this.cells[row_i] = new Array();
 
-    var row_columns = table_rows[row_i].split("\|");
+    var row_columns = table_rows[row_i].split(/(?<!\\)\|/g);
 
     for (var col_i = 0, col_l = row_columns.length; col_i < col_l; col_i = col_i + 1) {
       this.cells[row_i][col_i] = row_columns[col_i]


### PR DESCRIPTION
Hi,

This PR adds support for the escaped pipes, which allows markdown tables to contain pipes, like:

```
| h1          | h2     |
|-------------|--------|
| a           | b \| c |
| a \| b \| c | d      |
``` 

| h1          | h2     |
|-------------|--------|
| a           | b \| c |
| a \| b \| c | d      |